### PR TITLE
Add a "Open Configuration" button

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -477,6 +477,7 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, std::string pat
     QAction* open_lfs_location = context_menu.addAction(tr("Open Mod Data Location"));
     QAction* open_transferable_shader_cache =
         context_menu.addAction(tr("Open Transferable Shader Cache"));
+    QAction* open_configuration = context_menu.addAction(tr("Open Configuration"));
     context_menu.addSeparator();
     QAction* dump_romfs = context_menu.addAction(tr("Dump RomFS"));
     QAction* copy_tid = context_menu.addAction(tr("Copy Title ID to Clipboard"));
@@ -496,6 +497,8 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, std::string pat
     });
     connect(open_transferable_shader_cache, &QAction::triggered,
             [this, program_id]() { emit OpenTransferableShaderCacheRequested(program_id); });
+    connect(open_configuration, &QAction::triggered,
+            [this, program_id]() { emit OpenConfigurationRequested(program_id); });
     connect(dump_romfs, &QAction::triggered,
             [this, program_id, path]() { emit DumpRomFSRequested(program_id, path); });
     connect(copy_tid, &QAction::triggered,

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -75,6 +75,7 @@ signals:
     void ShouldCancelWorker();
     void OpenFolderRequested(GameListOpenTarget target, const std::string& game_path);
     void OpenTransferableShaderCacheRequested(u64 program_id);
+    void OpenConfigurationRequested(u64 program_id);
     void DumpRomFSRequested(u64 program_id, const std::string& game_path);
     void CopyTIDRequested(u64 program_id);
     void NavigateToGamedbEntryRequested(u64 program_id,

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -225,6 +225,7 @@ private:
     void HideMouseCursor();
     void ShowMouseCursor();
     void OpenURL(const QUrl& url);
+    void OpenFolderSpecifyingFile(const QString& file);
 
     Ui::MainWindow ui;
 


### PR DESCRIPTION
This works just like the "Open Transferable Shader Cache" button does, and its primary use is to be able to easily find the "configuration file" where the per-game configuration for a game is saved.

![screenshot](https://user-images.githubusercontent.com/63682805/87225334-696fe500-c38c-11ea-89a4-a95028c225db.png)
